### PR TITLE
Add Prometheus metrics endpoint and tests

### DIFF
--- a/app/obs.py
+++ b/app/obs.py
@@ -1,0 +1,62 @@
+import time
+from fastapi import FastAPI, Request, Response
+from prometheus_client import Counter, Histogram, CONTENT_TYPE_LATEST, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# Prometheus metric definitions
+http_requests_total = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "endpoint", "http_status"],
+)
+
+request_latency_seconds = Histogram(
+    "request_latency_seconds",
+    "Latency of HTTP requests in seconds",
+    ["endpoint"],
+)
+
+asr_partial_latency = Histogram(
+    "asr_partial_latency",
+    "Latency of partial ASR results in seconds",
+)
+
+asr_final_latency = Histogram(
+    "asr_final_latency",
+    "Latency of final ASR results in seconds",
+)
+
+llm_latency = Histogram(
+    "llm_latency",
+    "Latency of LLM responses in seconds",
+)
+
+score_overall_hist = Histogram(
+    "score_overall_hist",
+    "Histogram of overall scores",
+)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start_time = time.perf_counter()
+        response = await call_next(request)
+        latency = time.perf_counter() - start_time
+        endpoint = request.url.path
+        request_latency_seconds.labels(endpoint=endpoint).observe(latency)
+        http_requests_total.labels(
+            method=request.method,
+            endpoint=endpoint,
+            http_status=response.status_code,
+        ).inc()
+        return response
+
+
+def setup_metrics(app: FastAPI) -> None:
+    """Attach Prometheus metrics middleware and endpoint."""
+
+    app.add_middleware(MetricsMiddleware)
+
+    @app.get("/metrics")
+    async def metrics() -> Response:  # pragma: no cover - simple wrapper
+        return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 
+from app.obs import setup_metrics
 from app.schemas import IE, Coverage, Rubric, FinalScore
 
 app = FastAPI()
@@ -18,6 +19,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Observability hooks
+setup_metrics(app)
 
 
 @app.get("/healthz")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+prometheus_client
+httpx

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import app
+
+
+def test_metrics_endpoint_exposes_prometheus_metrics():
+    client = TestClient(app)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    data = response.text
+    assert "http_requests_total" in data
+    assert "request_latency_seconds" in data
+    assert "asr_partial_latency" in data
+    assert "asr_final_latency" in data
+    assert "llm_latency" in data
+    assert "score_overall_hist" in data


### PR DESCRIPTION
## Summary
- track HTTP and application latency metrics with Prometheus
- expose `/metrics` endpoint and supporting middleware
- verify metrics endpoint via tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9ff45294c83229a038df5e3165418