### PR TITLE
Add streaming websocket with VAD and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+logs/
+*.pyc

--- a/main.py
+++ b/main.py
@@ -1,11 +1,18 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
+import asyncio
 import io
+import json
+import logging
 import math
 import struct
+import time
 import uuid
 import wave
+from pathlib import Path
+
+from app.schemas import ASRChunk
 
 app = FastAPI()
 
@@ -16,6 +23,15 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+log_dir = Path("logs")
+log_dir.mkdir(exist_ok=True)
+logger = logging.getLogger("stream")
+logger.setLevel(logging.INFO)
+_handler = logging.FileHandler(log_dir / "stream.log")
+_handler.setFormatter(logging.Formatter("%(message)s"))
+logger.addHandler(_handler)
 
 
 @app.get("/healthz")
@@ -31,15 +47,77 @@ async def interview_start():
 
 
 @app.websocket("/stream/{session_id}")
-async def stream(session_id: str, websocket: WebSocket):
+async def stream(session_id: str, websocket: WebSocket, use_vad: bool = False):
     await websocket.accept()
+    vad = None
+    if use_vad:
+        try:
+            import webrtcvad
+
+            vad = webrtcvad.Vad(2)
+        except Exception:  # pragma: no cover - optional dependency
+            vad = None
+
+    text_buffer = ""
+    last_partial = 0.0
+    silence_ms = 0.0
+
+    def log_chunk(chunk: ASRChunk) -> None:
+        logger.info(json.dumps({"session_id": session_id, **chunk.model_dump()}))
+
+    def is_speech_pcm(pcm: bytes) -> bool:
+        if vad:
+            return vad.is_speech(pcm, 16000)
+        if not pcm:
+            return False
+        samples = struct.unpack("<" + "h" * (len(pcm) // 2), pcm)
+        energy = sum(abs(s) for s in samples) / len(samples)
+        return energy > 500
+
     try:
         while True:
-            data = await websocket.receive_text()
-            if data == "END":
-                await websocket.send_json({"type": "final", "text": data})
+            message = await websocket.receive()
+            if message.get("type") == "websocket.disconnect":
+                break
+            data = message.get("text")
+            if data is not None:
+                if data == "PING":
+                    await websocket.send_text("PONG")
+                    continue
+                if data == "END":
+                    chunk = ASRChunk(type="final", t0=0.0, t1=0.0, text=text_buffer)
+                    await websocket.send_json(chunk.model_dump())
+                    log_chunk(chunk)
+                    await websocket.close()
+                    break
+                text_buffer += data
+                now = time.monotonic()
+                if now - last_partial >= 0.25:
+                    chunk = ASRChunk(type="partial", t0=0.0, t1=0.0, text=text_buffer)
+                    await websocket.send_json(chunk.model_dump())
+                    log_chunk(chunk)
+                    last_partial = now
             else:
-                await websocket.send_json({"type": "partial", "text": data})
+                pcm = message.get("bytes") or b""
+                if not pcm:
+                    continue
+                if is_speech_pcm(pcm):
+                    silence_ms = 0.0
+                else:
+                    silence_ms += 20.0
+                    if silence_ms >= 400.0 and text_buffer:
+                        chunk = ASRChunk(type="final", t0=0.0, t1=0.0, text=text_buffer)
+                        await websocket.send_json(chunk.model_dump())
+                        log_chunk(chunk)
+                        text_buffer = ""
+                        await websocket.close()
+                        break
+                now = time.monotonic()
+                if now - last_partial >= 0.25:
+                    chunk = ASRChunk(type="partial", t0=0.0, t1=0.0, text=text_buffer)
+                    await websocket.send_json(chunk.model_dump())
+                    log_chunk(chunk)
+                    last_partial = now
     except WebSocketDisconnect:
         pass
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_ws_echo():
+    with client.websocket_connect("/stream/test-session") as ws:
+        ws.send_text("hello")
+        data = ws.receive_json()
+        assert data["type"] == "partial"
+        assert data["text"] == "hello"
+        ws.send_text("END")
+        data = ws.receive_json()
+        assert data["type"] == "final"
+        assert data["text"] == "hello"


### PR DESCRIPTION
## Summary
- implement `/stream/{session_id}` websocket handling PCM frames, PING keepalive and optional WebRTC VAD
- send partial and final `ASRChunk` messages and log them as JSON lines
- add echo test for websocket endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa04ac540c8322a0add962e363a4b8