### PR TITLE
feat: add LLMClient for OpenAI-compatible JSON generation

### DIFF
--- a/app/llm_client.py
+++ b/app/llm_client.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+import requests
+from jsonschema import validate
+
+
+class LLMClient:
+    """Minimal client for OpenAI-compatible chat completion API."""
+
+    def __init__(self, base_url: str, api_key: str | None, model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+
+    @classmethod
+    def from_env(cls) -> "LLMClient":
+        """Create client configured via environment variables."""
+        base_url = os.environ["VLLM_BASE_URL"]
+        model = os.environ.get("VLLM_MODEL", "Qwen/Qwen2.5-14B-Instruct")
+        api_key = os.environ.get("VLLM_API_KEY")
+        return cls(base_url=base_url, api_key=api_key, model=model)
+
+    def generate_json(
+        self,
+        prompt: str,
+        json_schema: Dict[str, Any],
+        temperature: float = 0.2,
+        max_tokens: int = 1024,
+    ) -> Dict[str, Any]:
+        """Generate JSON from the model and validate against ``json_schema``.
+
+        The LLM is instructed via system prompt to return *only* JSON.  When the
+        returned content cannot be parsed or does not validate against the
+        provided schema, the request is retried once more.  On success a Python
+        ``dict`` is returned.
+        """
+
+        url = f"{self.base_url}/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": "верни ТОЛЬКО валидный JSON по схеме"},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+
+        for _ in range(2):
+            resp = requests.post(url, headers=headers, json=payload, timeout=30)
+            resp.raise_for_status()
+            content = resp.json()["choices"][0]["message"]["content"]
+            try:
+                data = json.loads(content)
+                validate(data, json_schema)
+                return data
+            except Exception:
+                continue
+
+        raise ValueError("LLM did not return valid JSON")

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from unittest.mock import Mock, patch
+
+from pydantic import BaseModel
+
+from app.llm_client import LLMClient
+
+
+def test_generate_json_pydantic_validation(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "http://mock")
+    monkeypatch.setenv("VLLM_MODEL", "test-model")
+
+    client = LLMClient.from_env()
+
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+
+    class Result(BaseModel):
+        value: int
+
+    mock_resp = Mock()
+    mock_resp.json.return_value = {
+        "choices": [{"message": {"content": '{"value": 1}'}}]
+    }
+    mock_resp.raise_for_status.return_value = None
+
+    with patch("app.llm_client.requests.post", return_value=mock_resp) as mpost:
+        data = client.generate_json("prompt", schema)
+
+    Result(**data)
+    assert mpost.called


### PR DESCRIPTION
## Summary
- add LLMClient with env-configurable OpenAI-compatible HTTP interface
- implement JSON schema validation and retry logic
- test LLMClient JSON generation through Pydantic model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa077718e8832285fb4abee83d0d76