### PR TITLE
Implement /dm/next endpoint with JSON schema validation

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -80,6 +80,29 @@ class Coverage(BaseModel):
     per_competency: dict[str, float]
 
 
+class DMTurn(BaseModel):
+    role: Literal["user", "assistant"]
+    text: str
+
+
+class DMContext(BaseModel):
+    turns: list[DMTurn]
+
+
+class DMRequest(BaseModel):
+    jd: JD
+    context: DMContext
+    coverage: Coverage | None = None
+
+
+class NextAction(BaseModel):
+    action: Literal["ask", "end"]
+    question: str | None = None
+    followups: list[str] = Field(default_factory=list)
+    target_skill: str | None = None
+    reason: str
+
+
 class RubricEvidence(BaseModel):
     quote: str
     t0: float
@@ -122,8 +145,12 @@ __all__ = [
     "IEEvidence",
     "IESkill",
     "IEProject",
-    "IE",
+    "IE", 
     "Coverage",
+    "DMTurn",
+    "DMContext",
+    "DMRequest",
+    "NextAction",
     "RubricEvidence",
     "Rubric",
     "CompScore",

--- a/tests/test_dm_next.py
+++ b/tests/test_dm_next.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from main import app
+from app.llm_client import LLMClient
+
+
+client = TestClient(app)
+
+
+def sample_request():
+    return {
+        "jd": {
+            "role": "dev",
+            "lang": "en",
+            "competencies": [
+                {"name": "skill1", "weight": 1.0, "indicators": [{"name": "ind1"}]}
+            ],
+            "knockouts": [],
+        },
+        "context": {"turns": [{"role": "user", "text": "hi"}]},
+    }
+
+
+def test_dm_next_success(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "http://mock")
+    monkeypatch.setenv("VLLM_MODEL", "test-model")
+
+    def fake_generate_json(self, prompt, json_schema, temperature=0.2, max_tokens=1024):
+        return {
+            "action": "ask",
+            "question": "What is your experience?",
+            "followups": ["Tell me more"],
+            "target_skill": "skill1",
+            "reason": "Need info",
+        }
+
+    monkeypatch.setattr(LLMClient, "generate_json", fake_generate_json)
+    resp = client.post("/dm/next", json=sample_request())
+    assert resp.status_code == 200
+    assert resp.json()["action"] == "ask"
+
+
+def test_dm_next_invalid_json(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "http://mock")
+    monkeypatch.setenv("VLLM_MODEL", "test-model")
+    monkeypatch.setattr(
+        LLMClient,
+        "generate_json",
+        lambda self, prompt, json_schema, temperature=0.2, max_tokens=1024: {"foo": "bar"},
+    )
+
+    resp = client.post("/dm/next", json=sample_request())
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- add dialog management data models for turns, request, and action
- implement `/dm/next` endpoint with strict JSON schema validation and LLM integration
- test dialog manager for valid and invalid LLM responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1644e31c832282c721d5aa94e0ed