### PR TITLE
Add JD context builder with gap highlighting

### DIFF
--- a/app/context.py
+++ b/app/context.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from .schemas import JD
+
+
+def build_context(jd: JD, gaps: list[str] | None) -> str:
+    """Build a concise text summary of competencies and indicators.
+
+    Each competency is rendered as "<name> (<weight%>): <ind1>, <ind2>".
+    If ``gaps`` is provided, indicators matching the given words are
+    wrapped in asterisks to highlight them.
+    """
+    highlight = {g.lower() for g in gaps} if gaps else set()
+    parts: list[str] = []
+    for comp in jd.competencies:
+        indicators: list[str] = []
+        for ind in comp.indicators:
+            name = ind.name
+            if name.lower() in highlight:
+                name = f"*{name}*"
+            indicators.append(name)
+        parts.append(f"{comp.name} ({comp.weight:.0%}): {', '.join(indicators)}")
+    return "; ".join(parts)

--- a/tests/test_build_context.py
+++ b/tests/test_build_context.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.context import build_context
+from app.schemas import JD, JDCompetency, JDIndicator
+
+
+def test_build_context_highlights_gaps():
+    jd = JD(
+        role="dev",
+        lang="en",
+        competencies=[
+            JDCompetency(
+                name="skill",
+                weight=1.0,
+                indicators=[JDIndicator(name="monitoring")],
+            )
+        ],
+        knockouts=[],
+    )
+    context = build_context(jd, gaps=["monitoring"])
+    assert "monitoring" in context.lower()


### PR DESCRIPTION
## Summary
- add `build_context` helper to summarize JD competencies, weights and highlight specified gaps
- test `build_context` to ensure gap terms appear in context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa17d726988322acf47478be3fc94a