### PR TITLE
feat: add rubric scoring

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -87,6 +87,12 @@ class Coverage(BaseModel):
     per_competency: dict[str, float]
 
 
+class RubricScoreRequest(BaseModel):
+    jd: JD
+    transcript: str | IE
+    coverage: Coverage | None = None
+
+
 class DMTurn(BaseModel):
     role: Literal["user", "assistant"]
     text: str
@@ -155,6 +161,7 @@ __all__ = [
     "IE",
     "IEExtractRequest",
     "Coverage",
+    "RubricScoreRequest",
     "DMTurn",
     "DMContext",
     "DMRequest",

--- a/tests/test_rubric_score.py
+++ b/tests/test_rubric_score.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from main import app
+from app.llm_client import LLMClient
+
+
+client = TestClient(app)
+
+
+def sample_request():
+    return {
+        "jd": {
+            "role": "dev",
+            "lang": "en",
+            "competencies": [
+                {"name": "monitoring", "weight": 1.0, "indicators": [{"name": "monitoring"}]}
+            ],
+            "knockouts": [],
+        },
+        "transcript": "I worked on deployments and logging",
+    }
+
+
+def test_rubric_score_monitoring_missing(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "http://mock")
+    monkeypatch.setenv("VLLM_MODEL", "test-model")
+    calls = {"n": 0}
+
+    def fake_generate_json(self, prompt, json_schema, temperature=0.2, max_tokens=1024):
+        calls["n"] += 1
+        transcript_part = prompt.split("Transcript:\n", 1)[-1].lower()
+        if "monitoring" in transcript_part:
+            return {"scores": {"monitoring": 5}, "red_flags": [], "evidence": []}
+        return {
+            "scores": {"monitoring": 1},
+            "red_flags": ["no monitoring experience"],
+            "evidence": [],
+        }
+
+    monkeypatch.setattr(LLMClient, "generate_json", fake_generate_json)
+
+    resp = client.post("/rubric/score", json=sample_request())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scores"]["monitoring"] <= 1
+    assert any("monitoring" in rf.lower() for rf in data["red_flags"])
+    assert calls["n"] == 2
+


### PR DESCRIPTION
## Summary
- support rubric scoring via Qwen with 0-5 competency anchors and evidence collection
- merge two LLM samples for self-consistent rubric output
- flag missing "monitoring" in rubric scoring

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa1d1125f483229ea1ee212f26d56f