### PR TITLE
Implement feature-driven final scoring with model fallback

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -148,6 +148,14 @@ class FinalScore(BaseModel):
     by_comp: list[CompScore]
 
 
+class FinalScoreRequest(BaseModel):
+    jd: JD
+    ie: IE
+    coverage: Coverage | None = None
+    rubric: Rubric | None = None
+    aux: dict[str, object] = Field(default_factory=dict)
+
+
 __all__ = [
     "JDIndicator",
     "JDCompetency",
@@ -170,4 +178,5 @@ __all__ = [
     "Rubric",
     "CompScore",
     "FinalScore",
+    "FinalScoreRequest",
 ]

--- a/app/scoring.py
+++ b/app/scoring.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+import math
+from pathlib import Path
+from typing import Any
+
+from .schemas import JD, IE, Coverage, Rubric, FinalScore, CompScore
+
+
+def _slug(name: str) -> str:
+    """Convert arbitrary names to snake_case feature names."""
+    import re
+
+    return re.sub(r"[^0-9a-zA-Z]+", "_", name.strip().lower())
+
+
+def build_features(
+    jd: JD,
+    ie: IE,
+    coverage: Coverage | None,
+    rubric: Rubric | None,
+    aux: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build feature mapping used for final scoring."""
+
+    features: dict[str, Any] = {}
+    if coverage:
+        for name, val in coverage.per_competency.items():
+            features[f"coverage_{_slug(name)}"] = float(val)
+    if rubric:
+        for name, val in rubric.scores.items():
+            features[f"rubric_{_slug(name)}"] = float(val)
+    for name, years in ie.years.items():
+        features[f"years_{_slug(name)}"] = float(years)
+
+    count_metrics = sum(len(p.metrics) for p in ie.projects)
+    features["count_metrics"] = int(count_metrics)
+
+    if aux is None:
+        aux = {}
+    # numbers are passed in aux["numbers"] as list of numbers
+    numbers = aux.get("numbers", [])
+    features["count_numbers"] = int(len(numbers))
+    features["contradictions"] = int(aux.get("contradictions", 0))
+    features["toxicity"] = int(aux.get("toxicity", 0))
+    features["ko_flags"] = int(aux.get("ko_flags", 0))
+    features["asr_conf"] = float(aux.get("asr_conf", 0.0))
+    title = str(aux.get("title_canonical", ""))
+    if title:
+        features["title_canonical"] = hashlib.md5(title.encode()).hexdigest()
+    else:
+        features["title_canonical"] = ""
+    return features
+
+
+def _predict_probability(features: dict[str, Any]) -> float:
+    """Predict probability using optional CatBoost model or stub logistic regression."""
+
+    model_dir = Path("models")
+    cat_model = model_dir / "catboost.cbm"
+    calibrator = model_dir / "calibrator.pkl"
+    if cat_model.exists() and calibrator.exists():  # pragma: no cover - optional path
+        try:
+            from catboost import CatBoostClassifier
+            import numpy as np
+            import pickle
+
+            model = CatBoostClassifier()
+            model.load_model(str(cat_model))
+            with open(calibrator, "rb") as f:
+                calib = pickle.load(f)
+            numeric_keys = [
+                k
+                for k, v in features.items()
+                if isinstance(v, (int, float))
+            ]
+            numeric_vals = [features[k] for k in numeric_keys]
+            X = np.array([numeric_vals])
+            prob = float(model.predict_proba(X)[0][1])
+            prob = float(calib.predict_proba([[prob]])[0][1])
+            return prob
+        except Exception:
+            pass  # fall back to stub below
+
+    # Stub logistic regression using coverage and rubric averages
+    coverage_vals = [
+        v for k, v in features.items() if k.startswith("coverage_") and isinstance(v, (int, float))
+    ]
+    rubric_vals = [
+        v for k, v in features.items() if k.startswith("rubric_") and isinstance(v, (int, float))
+    ]
+    coverage_avg = sum(coverage_vals) / len(coverage_vals) if coverage_vals else 0.0
+    rubric_avg = (
+        sum(rubric_vals) / (5.0 * len(rubric_vals)) if rubric_vals else 0.0
+    )
+    z = coverage_avg + rubric_avg
+    return 1 / (1 + math.exp(-z))
+
+
+def final_score(
+    jd: JD,
+    ie: IE,
+    coverage: Coverage | None,
+    rubric: Rubric | None,
+    aux: dict[str, Any] | None,
+) -> FinalScore:
+    """Compute final score, decision and reasons."""
+
+    features = build_features(jd, ie, coverage, rubric, aux)
+    prob = _predict_probability(features)
+    if prob > 0.8:
+        decision = "move"
+    elif prob > 0.6:
+        decision = "discuss"
+    else:
+        decision = "reject"
+
+    reasons: list[str] = []
+    if coverage:
+        for name, val in coverage.per_competency.items():
+            if val < 0.5:
+                reasons.append(f"low coverage for {name}")
+    if rubric:
+        for name, val in rubric.scores.items():
+            if val < 3:
+                reasons.append(f"low rubric for {name}")
+        reasons.extend(rubric.red_flags)
+
+    by_comp: list[CompScore] = []
+    if coverage:
+        for name, val in coverage.per_competency.items():
+            by_comp.append(CompScore(name=name, score=float(val)))
+
+    return FinalScore(overall=prob, decision=decision, reasons=reasons, by_comp=by_comp)
+
+
+__all__ = ["build_features", "final_score"]

--- a/main.py
+++ b/main.py
@@ -23,9 +23,12 @@ from app.schemas import (
     Rubric,
     Coverage,
     RubricEvidence,
+    FinalScoreRequest,
+    FinalScore,
 )
 from app.tts import pcm_to_wav, stream_bytes, synthesize
 from app.ie import extract_ie
+from app.scoring import final_score as compute_final_score
 
 app = FastAPI()
 
@@ -265,8 +268,8 @@ async def rubric_score(req: RubricScoreRequest) -> Rubric:
 
 
 @app.post("/score/final")
-async def score_final():
-    return {"result": "stub"}
+async def score_final(req: FinalScoreRequest) -> FinalScore:
+    return compute_final_score(req.jd, req.ie, req.coverage, req.rubric, req.aux)
 
 
 @app.post("/report")

--- a/tests/test_final_score.py
+++ b/tests/test_final_score.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from main import app
+from app.scoring import build_features
+from app.schemas import (
+    JD,
+    JDCompetency,
+    JDIndicator,
+    IE,
+    Coverage,
+    Rubric,
+    RubricEvidence,
+)
+
+client = TestClient(app)
+
+
+def sample_jd():
+    return JD(
+        role="dev",
+        lang="en",
+        competencies=[
+            JDCompetency(
+                name="monitoring",
+                weight=1.0,
+                indicators=[JDIndicator(name="monitoring")],
+            )
+        ],
+        knockouts=[],
+    )
+
+
+def test_build_features_years():
+    jd = sample_jd()
+    ie = IE(skills=[], tools=[], years={"python": 5}, projects=[], roles=[])
+    coverage = Coverage(per_indicator={}, per_competency={})
+    rubric = Rubric(scores={}, red_flags=[], evidence=[])
+    feats = build_features(jd, ie, coverage, rubric, {})
+    assert feats["years_python"] == 5.0
+
+
+def test_low_coverage_not_move():
+    payload = {
+        "jd": sample_jd().model_dump(),
+        "ie": IE(skills=[], tools=[], years={}, projects=[], roles=[]).model_dump(),
+        "coverage": {
+            "per_indicator": {},
+            "per_competency": {"monitoring": 0.2},
+        },
+        "rubric": {
+            "scores": {"monitoring": 5},
+            "red_flags": [],
+            "evidence": [],
+        },
+        "aux": {},
+    }
+    resp = client.post("/score/final", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["decision"] != "move"


### PR DESCRIPTION
## Summary
- add scoring module with feature builder and logistic regression fallback
- expose `/score/final` endpoint using new model
- cover final scoring with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e33e6bc8322b8f8bb449e87249f