### PR TITLE
Add report generation and ATS sync endpoints

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -156,6 +156,25 @@ class FinalScoreRequest(BaseModel):
     aux: dict[str, object] = Field(default_factory=dict)
 
 
+class ReportRequest(BaseModel):
+    """Request schema for ``/report`` endpoint."""
+
+    candidate: str | None = None
+    vacancy: str | None = None
+    rubric: Rubric
+    final: FinalScore
+    audio_url: str = "audio"
+
+
+class ATSSyncRequest(BaseModel):
+    """Request schema for ``/ats/sync`` endpoint."""
+
+    candidate_id: str
+    vacancy_id: str
+    decision: str
+    report_link: str
+
+
 __all__ = [
     "JDIndicator",
     "JDCompetency",
@@ -179,4 +198,6 @@ __all__ = [
     "CompScore",
     "FinalScore",
     "FinalScoreRequest",
+    "ReportRequest",
+    "ATSSyncRequest",
 ]

--- a/app/templates/report.html
+++ b/app/templates/report.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Interview Report</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>Interview Report</h1>
+    {% if candidate %}<p>Candidate: {{ candidate }}</p>{% endif %}
+    {% if vacancy %}<p>Vacancy: {{ vacancy }}</p>{% endif %}
+    <h2>Overall: {{ overall_pct }}%</h2>
+    <canvas id="radar" width="400" height="400"></canvas>
+    <script>
+        const radarData = {
+            labels: {{ labels | tojson }},
+            datasets: [{
+                label: 'Scores',
+                data: {{ scores | tojson }},
+            }]
+        };
+        new Chart(document.getElementById('radar'), {type: 'radar', data: radarData});
+    </script>
+    <h2>Evidence</h2>
+    <table border="1">
+        <tr><th>Quote</th><th>Competency</th></tr>
+        {% for ev in rubric.evidence %}
+        <tr>
+            <td><a href="{{ audio_url }}?t0={{ ev.t0 }}&t1={{ ev.t1 }}">{{ ev.quote }}</a></td>
+            <td>{{ ev.competency }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <h2>Reasons</h2>
+    <ul>
+        {% for reason in final.reasons %}
+        <li>{{ reason }}</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 httpx
 jsonschema
 faiss-cpu
+jinja2

--- a/tests/test_ats_sync.py
+++ b/tests/test_ats_sync.py
@@ -1,0 +1,37 @@
+import types
+from fastapi.testclient import TestClient
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from main import app
+import os
+
+client = TestClient(app)
+
+class DummyResp:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+        self.text = "ok"
+
+def test_ats_sync_sends_payload(monkeypatch):
+    called = {}
+
+    def fake_post(url, json, headers, timeout):
+        called['url'] = url
+        called['json'] = json
+        called['headers'] = headers
+        return DummyResp()
+
+    monkeypatch.setenv("MOCK_ATS_URL", "http://mock")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    payload = {
+        "candidate_id": "cand1",
+        "vacancy_id": "vac1",
+        "decision": "move",
+        "report_link": "http://report"
+    }
+    resp = client.post("/ats/sync", json=payload)
+    assert resp.status_code == 200
+    assert called['url'] == "http://mock"
+    assert called['json'] == payload
+    assert called['headers']['Idempotency-Key'] == "cand1:vac1"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from main import app
+from app.schemas import Rubric, RubricEvidence, FinalScore, CompScore
+
+client = TestClient(app)
+
+def make_payload():
+    rubric = Rubric(
+        scores={"Python": 4, "ML": 3},
+        red_flags=[],
+        evidence=[
+            RubricEvidence(quote="foo", t0=0.0, t1=1.0, competency="Python"),
+            RubricEvidence(quote="bar", t0=1.0, t1=2.0, competency="ML"),
+        ],
+    )
+    final = FinalScore(
+        overall=0.75,
+        decision="move",
+        reasons=["good"],
+        by_comp=[CompScore(name="Python", score=0.8)],
+    )
+    return {"candidate": "John", "vacancy": "Dev", "rubric": rubric.model_dump(), "final": final.model_dump()}
+
+
+def test_report_contains_competencies_and_overall():
+    payload = make_payload()
+    resp = client.post("/report", json=payload)
+    assert resp.status_code == 200
+    html = resp.text
+    assert "Overall: 75%" in html
+    for comp in ["Python", "ML"]:
+        assert comp in html


### PR DESCRIPTION
## Summary
- implement HTML report endpoint with optional PDF export
- add ATS sync endpoint posting decisions with retry and idempotency
- include tests for report contents and ATS sync

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1f2979c48322b61c3f151201ba19