### PR TITLE
Enhance HR match parser with skill taxonomy and scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@
 
 ## История
 Снимок полного кода доступен по тегу `archive-pre-readme-only-20250825` и ветке `archive/full-code-20250825`.
+
+## Качество и конфиг
+
+* Навыки и синонимы расширяются в `data/skills_taxonomy.csv`. Каждая строка содержит колонку `canonical` и список `synonyms` через `;`.
+* Веса скоринга, пороги RapidFuzz и семантического совпадения настраиваются в `config/scoring.yaml`.
+* Для ускорения загрузки моделей Sentence-Transformers можно заранее скачать их в каталог, указанный переменной `MODELS_DIR`. Для кэша HuggingFace используется `HF_HOME` (по умолчанию `~/.cache/huggingface`).
+* Docker-сборка: `docker build -t hr-match .` и запуск `docker run hr-match`.

--- a/config/scoring.yaml
+++ b/config/scoring.yaml
@@ -1,0 +1,12 @@
+weights:
+  semantic: 0.5
+  skills: 0.3
+  title: 0.2
+thresholds:
+  skill_fuzzy: 90
+  skill_semantic: 0.72
+penalties:
+  lacking_years: 10.0
+  missing_musthave: 5.0
+language:
+  default: en

--- a/data/skills_taxonomy.csv
+++ b/data/skills_taxonomy.csv
@@ -1,0 +1,10 @@
+canonical,synonyms
+python,py;py3;python3
+pytorch,torch;pytorch lightning;pl
+postgresql,postgres;postgre;psql
+sql,structured query language
+docker,docker engine
+kubernetes,k8s;kube
+aws,amazon web services;ec2;s3
+gcp,google cloud;bigquery
+nlp,natural language processing

--- a/src/hr_match_mcp/__init__.py
+++ b/src/hr_match_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""HR Match MCP package."""
+from .models import HRModels
+from .parsing import extract_skills, extract_title, extract_experience_periods, total_years, parse_resume, parse_job
+from .scoring import must_have_covered, combine_score, score_resume
+from .server import parse_pdf, score

--- a/src/hr_match_mcp/models.py
+++ b/src/hr_match_mcp/models.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable, Set
+
+import numpy as np
+from langdetect import detect
+import spacy
+from spacy.matcher import PhraseMatcher
+import csv
+import hashlib
+
+try:  # pragma: no cover - optional dependency
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover
+    SentenceTransformer = None  # type: ignore
+
+
+@lru_cache(maxsize=1)
+def load_taxonomy(path: str | Path) -> Dict[str, Set[str]]:
+    """Load skills taxonomy from CSV.
+
+    The CSV must contain columns ``canonical`` and ``synonyms`` where
+    synonyms are separated by ``;``.
+    """
+    taxonomy: Dict[str, Set[str]] = {}
+    with open(path, newline='', encoding='utf8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            canonical = row["canonical"].strip().lower()
+            syns = {s.strip().lower() for s in row.get("synonyms", "").split(";") if s.strip()}
+            taxonomy[canonical] = syns
+    return taxonomy
+
+
+def build_phrase_matcher(nlp: spacy.language.Language, taxonomy: Dict[str, Set[str]]) -> PhraseMatcher:
+    matcher = PhraseMatcher(nlp.vocab, attr="LOWER")
+    for canonical, syns in taxonomy.items():
+        phrases = [canonical, *syns]
+        patterns = [nlp.make_doc(p) for p in phrases]
+        matcher.add(canonical, patterns)
+    return matcher
+
+
+def encode_canonical_skills(embed: SentenceTransformer, taxonomy: Dict[str, Set[str]]) -> Dict[str, np.ndarray]:
+    keys = list(taxonomy.keys())
+    vecs = embed.encode(keys, normalize_embeddings=True)
+    return {k: v for k, v in zip(keys, vecs)}
+
+
+class DummySentenceTransformer:
+    """Fallback encoder when sentence-transformers is unavailable."""
+
+    def encode(self, texts: Iterable[str], normalize_embeddings: bool = True):  # type: ignore[override]
+        vecs = []
+        for t in texts:
+            h = hashlib.sha256(t.lower().encode()).digest()
+            arr = np.frombuffer(h, dtype=np.uint8).astype(np.float32)[:32]
+            if normalize_embeddings:
+                norm = np.linalg.norm(arr) or 1.0
+                arr = arr / norm
+            vecs.append(arr)
+        return np.stack(vecs)
+
+
+def _load_st_model(name: str):
+    if SentenceTransformer is None:
+        return DummySentenceTransformer()
+    try:
+        mdl_dir = os.getenv("MODELS_DIR")
+        if mdl_dir:
+            local = Path(mdl_dir) / name.replace("/", "__")
+            if local.exists():
+                return SentenceTransformer(str(local))
+        return SentenceTransformer(name, cache_folder=os.getenv("HF_HOME"))
+    except Exception:  # pragma: no cover - network failures
+        return DummySentenceTransformer()
+
+
+class HRModels:
+    """Container for heavy NLP models and resources."""
+
+    def __init__(self, use_alt: bool = False, taxonomy_path: str | None = "data/skills_taxonomy.csv") -> None:
+        model_name = "sentence-transformers/paraphrase-MiniLM-L3-v2" if not use_alt else "sentence-transformers/all-MiniLM-L6-v2"
+        self.embed = _load_st_model(model_name)
+        self.taxonomy = load_taxonomy(Path(taxonomy_path)) if taxonomy_path else {}
+        self.skill_nlp = spacy.blank("en")
+        self.phrase_matcher = build_phrase_matcher(self.skill_nlp, self.taxonomy)
+        self.skill_vectors = encode_canonical_skills(self.embed, self.taxonomy)
+
+    @staticmethod
+    def detect_language(text: str) -> str:
+        try:
+            return detect(text)
+        except Exception:
+            return "unknown"
+
+    @lru_cache(maxsize=1024)
+    def embed_text(self, text: str) -> np.ndarray:
+        return self.embed.encode([text], normalize_embeddings=True)[0]

--- a/src/hr_match_mcp/parsing.py
+++ b/src/hr_match_mcp/parsing.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import base64
+import re
+from datetime import date, datetime
+from functools import lru_cache
+from typing import Iterable, List, Tuple
+
+import numpy as np
+from rapidfuzz import fuzz, process
+import dateparser
+import spacy
+
+from .models import HRModels
+
+
+# ------------------- Skills -------------------
+
+def _generate_ngrams(words: List[str], max_n: int = 3) -> Iterable[str]:
+    for n in range(1, max_n + 1):
+        for i in range(len(words) - n + 1):
+            yield " ".join(words[i : i + n])
+
+
+def extract_skills(text: str, models: HRModels, cfg: dict) -> List[str]:
+    """Return list of canonical skills mentioned in text."""
+    nlp = models.skill_nlp
+    doc = nlp(text)
+    found: set[str] = set()
+    # Step 1: PhraseMatcher
+    matches = models.phrase_matcher(doc)
+    for _, start, end in matches:
+        span = doc[start:end]
+        found.add(span.label_ or span.text.lower())
+    # Normalize to canonical for phrase matches
+    canonical_map = {s: c for c, syns in models.taxonomy.items() for s in {c, *syns}}
+    found = {canonical_map.get(f, f) for f in found}
+
+    if found:
+        pass
+    else:
+        # Step 2: fuzzy against all synonyms
+        syn_map = {s: c for c, syns in models.taxonomy.items() for s in syns}
+        words = re.findall(r"[\w#+]+", text.lower())
+        for ng in _generate_ngrams(words):
+            best = process.extractOne(ng, syn_map.keys(), scorer=fuzz.ratio, score_cutoff=cfg["thresholds"]["skill_fuzzy"])
+            if best:
+                found.add(syn_map[best[0]])
+
+    # Step 4: semantic fallback for unmatched tokens (limited to up to 50 unique tokens)
+    if cfg and cfg["thresholds"].get("skill_semantic"):
+        syn_map = {s: c for c, syns in models.taxonomy.items() for s in {c, *syns}}
+        all_words = {w for w in re.findall(r"[\w#+]+", text.lower()) if w not in syn_map}
+        for w in list(all_words)[:50]:
+            vec = models.embed_text(w)
+            sims = {c: float(vec @ models.skill_vectors[c]) for c in models.skill_vectors}
+            if sims:
+                best_c, best_sim = max(sims.items(), key=lambda x: x[1])
+                if best_sim >= cfg["thresholds"]["skill_semantic"]:
+                    found.add(best_c)
+
+    return sorted(found)
+
+
+# ------------------- Title extraction -------------------
+
+def extract_title(text: str) -> str | None:
+    pattern = re.compile(r"(Data|ML|Backend|Frontend|QA|Руководитель|Аналитик|Разработчик|Инженер)", re.I)
+    m = pattern.search(text)
+    return m.group(0) if m else None
+
+
+# ------------------- Experience -------------------
+
+_interval_re = re.compile(
+    r"(?P<start>[A-Za-zА-Яа-я]{3,9}\s+\d{4}|\d{1,2}[./]\d{4}|\d{4})\s*[-–—]\s*(?P<end>Present|Now|Current|[A-Za-zА-Яа-я]{3,9}\s+\d{4}|\d{1,2}[./]\d{4}|\d{4})",
+    re.I,
+)
+
+
+def _parse_dt(text: str) -> date | None:
+    text = text.strip()
+    if re.fullmatch(r"\d{4}", text):
+        return date(int(text), 1, 1)
+    dt = dateparser.parse(text, languages=["en", "ru"])
+    if dt:
+        return dt.date().replace(day=1)
+    return None
+
+
+def extract_experience_periods(text: str) -> List[Tuple[date, date]]:
+    periods: List[Tuple[date, date]] = []
+    for m in _interval_re.finditer(text):
+        start_raw, end_raw = m.group("start"), m.group("end")
+        start = _parse_dt(start_raw)
+        if not start:
+            continue
+        if re.match(r"present|now|current", end_raw, re.I):
+            end = date.today()
+        else:
+            end = _parse_dt(end_raw)
+            if end and len(end_raw) == 4:
+                # Year-only, interpret as Jan 1 of year
+                pass
+        if start and end and end >= start:
+            periods.append((start, end))
+    return periods
+
+
+def merge_intervals(intervals: List[Tuple[date, date]]) -> List[Tuple[date, date]]:
+    if not intervals:
+        return []
+    intervals = sorted(intervals, key=lambda x: x[0])
+    merged = [list(intervals[0])]
+    for s, e in intervals[1:]:
+        last_s, last_e = merged[-1]
+        if s <= last_e:
+            merged[-1][1] = max(last_e, e)
+        else:
+            merged.append([s, e])
+    return [(s, e) for s, e in merged]
+
+
+def years_between(s: date, e: date) -> float:
+    return (e - s).days / 365.25
+
+
+def total_years(periods: Iterable[Tuple[date, date]]) -> float:
+    merged = merge_intervals(list(periods))
+    total = sum(years_between(s, e) for s, e in merged)
+    return round(total, 2)
+
+
+# ------------------- Resume/Job parsing -------------------
+
+def parse_resume(text: str, models: HRModels, cfg: dict) -> dict:
+    title = extract_title(text) or ""
+    skills = extract_skills(text, models, cfg)
+    periods = extract_experience_periods(text)
+    years = total_years(periods)
+    lang = models.detect_language(text)
+    return {"title": title, "skills": skills, "years_exp": years, "lang": lang}
+
+
+def _extract_section(text: str, headers: Iterable[str]) -> str:
+    pattern = r"|".join(re.escape(h) for h in headers)
+    regex = re.compile(rf"({pattern})(.*?)(\n\n|$)", re.I | re.S)
+    m = regex.search(text)
+    return m.group(2) if m else ""
+
+
+def parse_job(text: str, models: HRModels, cfg: dict) -> dict:
+    title = extract_title(text) or ""
+    must_text = _extract_section(text, ["Requirements", "Требования", "Must have", "Обязательно"])
+    must_skills = extract_skills(must_text, models, cfg)
+    skills = extract_skills(text, models, cfg)
+    lang = models.detect_language(text)
+    return {"title": title, "skills": skills, "must": must_skills, "lang": lang}

--- a/src/hr_match_mcp/scoring.py
+++ b/src/hr_match_mcp/scoring.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+import yaml
+
+from .models import HRModels
+
+
+@lru_cache(maxsize=1)
+def read_yaml_config(path: str = "config/scoring.yaml") -> dict:
+    with open(path, encoding="utf8") as f:
+        return yaml.safe_load(f)
+
+
+def must_have_covered(
+    jd_must: List[str],
+    cv_skills: List[str],
+    skill_vectors: Dict[str, np.ndarray],
+    semantic_thr: float,
+) -> Tuple[bool, List[str]]:
+    cv_vecs = [skill_vectors[s] for s in cv_skills if s in skill_vectors]
+    missing: List[str] = []
+    for m in jd_must:
+        if m in cv_skills:
+            continue
+        mv = skill_vectors.get(m)
+        if mv is not None and cv_vecs:
+            sims = [float(mv @ v) for v in cv_vecs]
+            if sims and max(sims) >= semantic_thr:
+                continue
+        missing.append(m)
+    return (len(missing) == 0, missing)
+
+
+def skills_overlap(jd_skills: Iterable[str], cv_skills: Iterable[str]) -> Tuple[List[str], List[str], List[str]]:
+    jd_set = set(jd_skills)
+    cv_set = set(cv_skills)
+    tp = sorted(jd_set & cv_set)
+    fn = sorted(jd_set - cv_set)
+    fp = sorted(cv_set - jd_set)
+    return tp, fn, fp
+
+
+def combine_score(S_sem: float, S_skill: float, S_title: float, penalty: float, weights: Dict[str, float]) -> float:
+    total = (
+        weights.get("semantic", 0) * S_sem
+        + weights.get("skills", 0) * S_skill
+        + weights.get("title", 0) * S_title
+    )
+    total = total * 100 - penalty
+    return round(max(total, 0.0), 2)
+
+
+def score_resume(cv: dict, jd: dict, models: HRModels, cfg: dict) -> Tuple[float, dict, dict]:
+    thr = cfg["thresholds"]["skill_semantic"]
+    covered, missing = must_have_covered(jd["must"], cv["skills"], models.skill_vectors, thr)
+    tp, fn, fp = skills_overlap(jd["skills"], cv["skills"])
+    S_sem = 1.0 if covered else 0.0
+    S_skill = len(tp) / max(len(jd["skills"]), 1)
+    S_title = 1.0 if cv["title"] and jd["title"] and cv["title"].lower() == jd["title"].lower() else 0.0
+    penalty = 0.0
+    if cv["years_exp"] < 0:
+        penalty += cfg["penalties"]["lacking_years"]
+    if not covered:
+        penalty += cfg["penalties"]["missing_musthave"]
+    score = combine_score(S_sem, S_skill, S_title, penalty, cfg["weights"])
+    parts = {
+        "sem": S_sem,
+        "skills": S_skill,
+        "title": S_title,
+        "penalty": penalty,
+        "skills_tp": tp,
+        "skills_fn": fn,
+        "skills_fp": fp,
+    }
+    debug = {
+        "cv_title": cv["title"],
+        "jd_title": jd["title"],
+        "missing_must": missing,
+        "thresholds": cfg["thresholds"],
+    }
+    return score, parts, debug

--- a/src/hr_match_mcp/server.py
+++ b/src/hr_match_mcp/server.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any, Dict
+
+import fitz  # PyMuPDF
+
+from .models import HRModels
+from .parsing import parse_job, parse_resume
+from .scoring import read_yaml_config, score_resume
+
+
+_models_cache: dict[bool, HRModels] = {}
+
+
+def _get_models(use_alt: bool) -> HRModels:
+    if use_alt not in _models_cache:
+        _models_cache[use_alt] = HRModels(use_alt=use_alt)
+    return _models_cache[use_alt]
+
+
+def parse_pdf(resume_pdf_base64: str) -> Dict[str, Any]:
+    data = base64.b64decode(resume_pdf_base64)
+    try:
+        doc = fitz.open(stream=data, filetype="pdf")
+        text = "\n".join(page.get_text() for page in doc)
+    except Exception:
+        text = data.decode("utf8", errors="ignore")
+    cfg = read_yaml_config()
+    models = _get_models(False)
+    res = parse_resume(text, models, cfg)
+    preview = text[:200]
+    return {
+        "title": res["title"],
+        "skills": res["skills"],
+        "years_exp": res["years_exp"],
+        "text_preview": preview,
+        "debug": {"lang": res["lang"]},
+    }
+
+
+def score(resume_pdf_base64: str, job_text: str, use_alt: bool = False) -> Dict[str, Any]:
+    data = base64.b64decode(resume_pdf_base64)
+    try:
+        doc = fitz.open(stream=data, filetype="pdf")
+        cv_text = "\n".join(page.get_text() for page in doc)
+    except Exception:
+        cv_text = data.decode("utf8", errors="ignore")
+    models = _get_models(use_alt)
+    cfg = read_yaml_config()
+    cv = parse_resume(cv_text, models, cfg)
+    jd = parse_job(job_text, models, cfg)
+    final, parts, debug = score_resume(cv, jd, models, cfg)
+    debug.update({"lang_cv": cv["lang"], "lang_jd": jd["lang"]})
+    return {"score": final, "parts": parts, "debug": debug}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure src is on path
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1,0 +1,20 @@
+from datetime import date
+
+from hr_match_mcp.parsing import extract_experience_periods, total_years
+
+
+class FixedDate(date):
+    @classmethod
+    def today(cls):
+        return cls(2024, 1, 1)
+
+
+def test_experience_periods_and_total_years(monkeypatch):
+    monkeypatch.setattr("hr_match_mcp.parsing.date", FixedDate)
+    text = (
+        "Worked at X 2018-2020. Then Y Jan 2019 - Present. Also Z Март 2019 — Июль 2023."
+    )
+    periods = extract_experience_periods(text)
+    assert len(periods) == 3
+    years = total_years(periods)
+    assert 5.9 < years < 6.1

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from hr_match_mcp.scoring import combine_score, must_have_covered, read_yaml_config
+
+
+def test_must_have_semantic_and_weights():
+    vecs = {
+        "gcp": np.array([1.0, 0.0]),
+        "google cloud": np.array([0.9, 0.1]),
+        "aws": np.array([0.0, 1.0]),
+    }
+    covered, _ = must_have_covered(["gcp"], ["google cloud"], vecs, 0.8)
+    assert covered
+    covered2, _ = must_have_covered(["gcp"], ["aws"], vecs, 0.8)
+    assert not covered2
+
+    cfg = read_yaml_config()
+    score = combine_score(1.0, 1.0, 1.0, 0.0, cfg["weights"])
+    assert score == 100.0

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,14 @@
+from hr_match_mcp.models import HRModels
+from hr_match_mcp.parsing import extract_skills
+from hr_match_mcp.scoring import read_yaml_config
+
+
+def test_skill_normalization_and_semantics():
+    models = HRModels()
+    cfg = read_yaml_config()
+    text = "We use torch, k8s, Postgre and Big Query extensively."
+    skills = extract_skills(text, models, cfg)
+    assert "pytorch" in skills
+    assert "kubernetes" in skills
+    assert "postgresql" in skills
+    assert "gcp" in skills


### PR DESCRIPTION
## Summary
- add HRModels with taxonomy loading, cached embeddings and offline-friendly dummy sentence transformer
- implement skill extraction via PhraseMatcher, fuzzy and semantic matching plus experience period parsing
- provide configurable scoring with semantic must-have coverage and debug parts
- document config and taxonomy usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef0bb769883228383c13af6acc909