### PR TITLE
Add hypothesis stabilizer with drift handling

### DIFF
--- a/server/stabilizer.py
+++ b/server/stabilizer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Hypothesis stabilization utilities."""
+
+from collections import deque
+from typing import Deque, List
+
+
+class Stabilizer:
+    """Track stable prefix across streaming ASR hypotheses.
+
+    Parameters
+    ----------
+    n_history: int, optional
+        Number of latest hypotheses to keep for stability estimation. Defaults to 5.
+    delimiters: str, optional
+        Characters considered as token delimiters. Stable prefix is trimmed to
+        the last occurrence of any of these characters. Defaults to ``" .,!?"``.
+    """
+
+    def __init__(self, n_history: int = 5, delimiters: str = " .,!?") -> None:
+        self.n_history = n_history
+        self.delimiters = delimiters
+        self.history: Deque[str] = deque(maxlen=n_history)
+        self.stable_prefix: str = ""
+
+    def _longest_common_prefix(self, strs: List[str]) -> str:
+        if not strs:
+            return ""
+        prefix = strs[0]
+        for s in strs[1:]:
+            while not s.startswith(prefix) and prefix:
+                prefix = prefix[:-1]
+        return prefix
+
+    def _truncate_to_delim(self, text: str) -> str:
+        for i in range(len(text) - 1, -1, -1):
+            if text[i] in self.delimiters:
+                return text[: i + 1]
+        return ""
+
+    def get_delta(self, new_hyp: str) -> str:
+        """Return newly stabilized part of the hypothesis.
+
+        Parameters
+        ----------
+        new_hyp: str
+            Latest hypothesis string.
+
+        Returns
+        -------
+        str
+            Portion of text that became stable since last invocation.
+        """
+        self.history.append(new_hyp)
+
+        lcp = self._longest_common_prefix(list(self.history))
+        lcp = self._truncate_to_delim(lcp)
+
+        prev = self.stable_prefix
+        if not lcp.startswith(prev):
+            delta = ""
+        else:
+            delta = lcp[len(prev) :]
+        self.stable_prefix = lcp
+        return delta

--- a/tests/test_stabilizer.py
+++ b/tests/test_stabilizer.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from server.stabilizer import Stabilizer
+
+
+def test_drift_and_recovery():
+    stab = Stabilizer(n_history=2)
+
+    # Initial hypothesis becomes stable immediately
+    assert stab.get_delta("hello world ") == "hello world "
+    assert stab.stable_prefix == "hello world "
+
+    # Drift: hypothesis changes earlier word, stable prefix shrinks
+    assert stab.get_delta("hello there ") == ""
+    assert stab.stable_prefix == "hello "
+
+    # New words become stable after drift
+    assert stab.get_delta("hello there general") == "there "
+    assert stab.stable_prefix == "hello there "
+
+    # Repeating hypothesis confirms additional word
+    stab.get_delta("hello there general ")
+    assert stab.get_delta("hello there general ") == "general "
+    assert stab.stable_prefix == "hello there general "
+
+
+def test_multiple_drifts():
+    stab = Stabilizer(n_history=2)
+
+    stab.get_delta("foo bar ")
+    stab.get_delta("foo bar baz ")
+    assert stab.stable_prefix == "foo bar "
+
+    # Drift backward
+    stab.get_delta("foo baz ")
+    assert stab.stable_prefix == "foo "
+
+    # Another drift forward and confirmation
+    assert stab.get_delta("foo baz qux") == "baz "
+    stab.get_delta("foo baz qux ")
+    assert stab.get_delta("foo baz qux ") == "qux "
+    assert stab.stable_prefix == "foo baz qux "


### PR DESCRIPTION
## Summary
- Implement `Stabilizer` for tracking stable ASR prefix and handling drift
- Add unit tests covering drift scenarios and recovery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36b1c54b08322888c5b9b3dcc5664