### PR TITLE
Add Piper TTS synthesis

### DIFF
--- a/server/tts_piper.py
+++ b/server/tts_piper.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Text-to-speech utilities using Piper models."""
+
+from pathlib import Path
+
+import numpy as np
+
+try:  # pragma: no cover - environment may not have onnxruntime
+    import onnxruntime as ort
+except Exception:  # pragma: no cover
+    ort = None  # type: ignore
+
+try:  # pragma: no cover - environment may not have piper_phonemizer
+    from piper_phonemizer import piper_phonemize
+except Exception:  # pragma: no cover
+    piper_phonemize = None  # type: ignore
+
+
+class PiperTTS:
+    """Simple wrapper around a Piper ONNX model.
+
+    Parameters
+    ----------
+    model_path: str
+        Path to the Piper ONNX model.
+    speaker_json: str
+        Path to speaker configuration used for phonemization.
+    """
+
+    sample_rate = 16_000
+
+    def __init__(self, model_path: str, speaker_json: str) -> None:
+        self.model_path = model_path
+        self.speaker_json = speaker_json
+
+        if not Path(model_path).is_file():
+            raise FileNotFoundError(f"Piper model not found: {model_path}")
+
+        if ort is None:  # pragma: no cover - handled via mocks in tests
+            raise RuntimeError("onnxruntime is required for PiperTTS")
+
+        self.session = ort.InferenceSession(model_path)
+
+    def synthesize(self, text: str) -> bytes:
+        """Synthesize text into 16 kHz PCM16 audio.
+
+        Parameters
+        ----------
+        text: str
+            Text to synthesize.
+
+        Returns
+        -------
+        bytes
+            Raw PCM16 audio bytes at 16 kHz.
+        """
+        if piper_phonemize is None:  # pragma: no cover - handled via mocks in tests
+            raise RuntimeError("piper_phonemizer is required for phonemization")
+
+        phonemes = piper_phonemize(text, self.speaker_json)
+        audio = self.session.run(None, {"input": phonemes})[0]
+        audio = np.asarray(audio, dtype=np.float32)
+        audio = np.clip(audio, -1.0, 1.0)
+        pcm = (audio * 32767).astype(np.int16)
+        return pcm.tobytes()

--- a/tests/test_tts_piper.py
+++ b/tests/test_tts_piper.py
@@ -1,0 +1,51 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from server.tts_piper import PiperTTS
+
+
+class DummySession:
+    def __init__(self, expected_path: str, audio: np.ndarray):
+        self.expected_path = expected_path
+        self.audio = audio
+
+    def run(self, *_args, **_kwargs):
+        return [self.audio]
+
+
+def test_synthesize(monkeypatch, tmp_path):
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"")
+    speaker_json = tmp_path / "speaker.json"
+    speaker_json.write_text("{}")
+
+    audio = np.array([0.0, 0.5, -0.5], dtype=np.float32)
+
+    dummy_session = DummySession(str(model_path), audio)
+    monkeypatch.setattr(
+        "server.tts_piper.ort",
+        SimpleNamespace(InferenceSession=lambda path: dummy_session),
+    )
+    monkeypatch.setattr(
+        "server.tts_piper.piper_phonemize",
+        lambda text, speaker: np.array([1, 2, 3], dtype=np.int64),
+    )
+
+    tts = PiperTTS(str(model_path), str(speaker_json))
+    pcm_bytes = tts.synthesize("hello")
+
+    expected = (audio * 32767).astype(np.int16).tobytes()
+    assert pcm_bytes == expected
+
+
+def test_missing_model(tmp_path):
+    speaker_json = tmp_path / "speaker.json"
+    speaker_json.write_text("{}")
+
+    with pytest.raises(FileNotFoundError):
+        PiperTTS(str(tmp_path / "missing.onnx"), str(speaker_json))


### PR DESCRIPTION
## Summary
- implement PiperTTS class loading ONNX Piper model and synthesizing text to PCM16 audio
- add unit tests with mocks for phonemizer and ONNX runtime, including missing-model case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b36be8c75083228c6aa86d417d3067