### PR TITLE
Add WebSocket server assembling ASR and selectable TTS engines

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import websockets
+
+from rt_echo.common.config import load_config
+
+from .asr import AsrEngine
+from .session import EchoSession
+from .tts_piper import PiperTTS
+from .tts_silero import SileroTTS
+
+
+async def reader(ws: websockets.WebSocketServerProtocol, session: EchoSession) -> None:
+    """Receive binary PCM frames from the websocket and feed the session."""
+    async for message in ws:
+        if isinstance(message, bytes):
+            session.push(message)
+
+
+async def writer(ws: websockets.WebSocketServerProtocol, session: EchoSession) -> None:
+    """Run session processing loop and stream synthesized speech."""
+    await session.tick(ws)
+
+
+async def start_server() -> None:
+    """Load configuration, initialise engines and start websocket server."""
+    cfg = load_config()
+    asr = AsrEngine(cfg)
+
+    if cfg.tts_engine.lower() == "piper":
+        model_path = Path(f"{cfg.ru_speaker}.onnx")
+        speaker_json = Path(f"{cfg.ru_speaker}.json")
+        tts = PiperTTS(str(model_path), str(speaker_json))
+    elif cfg.tts_engine.lower() == "silero":
+        tts = SileroTTS(cfg.ru_speaker)
+    else:
+        raise ValueError(f"Unknown TTS engine: {cfg.tts_engine}")
+
+    async def handler(ws: websockets.WebSocketServerProtocol) -> None:
+        session = EchoSession(cfg, asr, tts)
+        r_task = asyncio.create_task(reader(ws, session))
+        w_task = asyncio.create_task(writer(ws, session))
+        done, pending = await asyncio.wait({r_task, w_task}, return_when=asyncio.FIRST_COMPLETED)
+        for task in pending:
+            task.cancel()
+
+    async with websockets.serve(handler, "0.0.0.0", cfg.ws_port):
+        await asyncio.Future()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(start_server())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry point
+    main()

--- a/server/tts_silero.py
+++ b/server/tts_silero.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Minimal Silero TTS placeholder used for tests and local development."""
+
+import numpy as np
+
+
+class SileroTTS:
+    """Simple stub implementation that outputs silence.
+
+    Parameters
+    ----------
+    speaker: str
+        Speaker identifier, kept for API compatibility.
+    device: str
+        Device identifier (e.g., "cpu"), unused in this stub.
+    """
+
+    sample_rate = 16_000
+
+    def __init__(self, speaker: str = "ru_v3", device: str = "cpu") -> None:
+        self.speaker = speaker
+        self.device = device
+
+    def synthesize(self, text: str) -> bytes:
+        """Return a short silence placeholder for the given text."""
+
+        duration = max(len(text) * 0.05, 0.2)  # seconds of audio
+        samples = int(self.sample_rate * duration)
+        pcm = np.zeros(samples, dtype=np.int16)
+        return pcm.tobytes()


### PR DESCRIPTION
## Summary
- Implement server startup with config loading, ASR init, and Piper/Silero TTS selection
- Handle WebSocket connections spawning reader and writer tasks
- Provide minimal SileroTTS stub for development

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3720eff4883229bf82e3991fa8b91