### PR TITLE
Add audio utilities and resampling support for TTS

### DIFF
--- a/common/audio.py
+++ b/common/audio.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+try:
+    from scipy import signal  # type: ignore
+except Exception:  # pragma: no cover
+    signal = None  # type: ignore
+
+try:
+    import resampy  # type: ignore
+except Exception:  # pragma: no cover
+    resampy = None  # type: ignore
+
+
+def float32_to_pcm16(audio: np.ndarray) -> bytes:
+    """Convert float32 numpy array to 16-bit PCM bytes."""
+    audio = np.asarray(audio, dtype=np.float32)
+    audio = np.clip(audio, -1.0, 1.0)
+    return (audio * 32767).astype(np.int16).tobytes()
+
+
+def pcm16_to_float32(pcm: bytes) -> np.ndarray:
+    """Convert 16-bit PCM bytes to float32 numpy array."""
+    audio = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
+    return audio / 32767.0
+
+
+def resample(audio: np.ndarray, src_sr: int, dst_sr: int) -> np.ndarray:
+    """Resample audio from src_sr to dst_sr.
+
+    Uses resampy or scipy if available, otherwise falls back to linear
+    interpolation with NumPy.
+    """
+    audio = np.asarray(audio, dtype=np.float32)
+    if src_sr == dst_sr:
+        return audio
+
+    if resampy is not None:  # pragma: no cover - only used when available
+        return resampy.resample(audio, src_sr, dst_sr)
+
+    if signal is not None:  # pragma: no cover - only used when available
+        duration = audio.shape[0] / float(src_sr)
+        n_samples = int(round(duration * dst_sr))
+        return signal.resample(audio, n_samples)
+
+    # Fallback: simple linear interpolation
+    ratio = dst_sr / float(src_sr)
+    x_old = np.linspace(0, len(audio), num=len(audio), endpoint=False)
+    x_new = np.linspace(0, len(audio), num=int(len(audio) * ratio), endpoint=False)
+    return np.interp(x_new, x_old, audio).astype(np.float32)

--- a/server/tts_silero.py
+++ b/server/tts_silero.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from common.audio import float32_to_pcm16
+
 
 class SileroTTS:
     """Simple stub implementation that outputs silence.
@@ -27,5 +29,5 @@ class SileroTTS:
 
         duration = max(len(text) * 0.05, 0.2)  # seconds of audio
         samples = int(self.sample_rate * duration)
-        pcm = np.zeros(samples, dtype=np.int16)
-        return pcm.tobytes()
+        silence = np.zeros(samples, dtype=np.float32)
+        return float32_to_pcm16(silence)

--- a/tests/test_tts_piper.py
+++ b/tests/test_tts_piper.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from common.audio import float32_to_pcm16, resample
 from server.tts_piper import PiperTTS
 
 
@@ -39,7 +40,7 @@ def test_synthesize(monkeypatch, tmp_path):
     tts = PiperTTS(str(model_path), str(speaker_json))
     pcm_bytes = tts.synthesize("hello")
 
-    expected = (audio * 32767).astype(np.int16).tobytes()
+    expected = float32_to_pcm16(audio)
     assert pcm_bytes == expected
 
 
@@ -49,3 +50,29 @@ def test_missing_model(tmp_path):
 
     with pytest.raises(FileNotFoundError):
         PiperTTS(str(tmp_path / "missing.onnx"), str(speaker_json))
+
+
+def test_resample(monkeypatch, tmp_path):
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"")
+    speaker_json = tmp_path / "speaker.json"
+    speaker_json.write_text("{}")
+
+    audio = np.linspace(-1, 1, 8, dtype=np.float32)
+
+    dummy_session = DummySession(str(model_path), audio)
+    monkeypatch.setattr(
+        "server.tts_piper.ort",
+        SimpleNamespace(InferenceSession=lambda path: dummy_session),
+    )
+    monkeypatch.setattr(
+        "server.tts_piper.piper_phonemize",
+        lambda text, speaker: np.array([1, 2, 3], dtype=np.int64),
+    )
+
+    tts = PiperTTS(str(model_path), str(speaker_json), model_sample_rate=8_000)
+    pcm_bytes = tts.synthesize("hello")
+
+    expected_audio = resample(audio, 8_000, tts.sample_rate)
+    expected = float32_to_pcm16(expected_audio)
+    assert pcm_bytes == expected


### PR DESCRIPTION
## Summary
- add `common.audio` module with float32/PCM16 conversions and resampling helpers
- use audio helpers in PiperTTS and SileroTTS
- support resampling when Piper model sample rate differs from target 16kHz
- extend PiperTTS tests for conversions and resampling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b372d26e988322a9ff4ec481d421fb