### PR TITLE
Add logging, metrics, and health endpoint

### DIFF
--- a/rt_echo/common/config.py
+++ b/rt_echo/common/config.py
@@ -13,6 +13,7 @@ class AppConfig:
     asr_compute_type: str = "int8"
     asr_sr: int = 16000
     ws_port: int = 8000
+    http_port: int = 8080
     tts_engine: str = "piper"
     ru_speaker: str = "kseniya_16khz"
 
@@ -26,6 +27,7 @@ def load_config() -> AppConfig:
         asr_compute_type=os.getenv("ASR_COMPUTE_TYPE", "int8"),
         asr_sr=int(os.getenv("ASR_SR", 16000)),
         ws_port=int(os.getenv("WS_PORT", 8000)),
+        http_port=int(os.getenv("HTTP_PORT", 8080)),
         tts_engine=os.getenv("TTS_ENGINE", "piper"),
         ru_speaker=os.getenv("RU_SPEAKER", "kseniya_16khz"),
     )

--- a/server/asr.py
+++ b/server/asr.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 """Automatic speech recognition utilities using faster-whisper."""
 
+import logging
 import numpy as np
 from faster_whisper import WhisperModel
+
+
+log = logging.getLogger(__name__)
 
 
 class AsrEngine:
@@ -22,6 +26,7 @@ class AsrEngine:
             device=config.asr_device,
             compute_type=config.asr_compute_type,
         )
+        log.info("ASR model loaded: %s", config.asr_model)
 
     def transcribe_window(self, audio: np.ndarray, lang: str = "ru") -> str:
         """Transcribe a window of PCM audio and return recognized text.
@@ -38,10 +43,13 @@ class AsrEngine:
         str
             Concatenated text from all transcription segments.
         """
+        log.debug("transcribe window size=%d", len(audio))
         segments, _ = self.model.transcribe(
             audio,
             language=lang,
             beam_size=1,
             vad_filter=True,
         )
-        return "".join(segment.text for segment in segments)
+        text = "".join(segment.text for segment in segments)
+        log.debug("transcription result: %s", text.strip())
+        return text

--- a/server/server.py
+++ b/server/server.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 
 import websockets
+from aiohttp import web
 
 from rt_echo.common.config import load_config
 
@@ -13,22 +14,35 @@ from .session import EchoSession
 from .tts_piper import PiperTTS
 from .tts_silero import SileroTTS
 
+log = logging.getLogger(__name__)
+
 
 async def reader(ws: websockets.WebSocketServerProtocol, session: EchoSession) -> None:
     """Receive binary PCM frames from the websocket and feed the session."""
     async for message in ws:
         if isinstance(message, bytes):
+            log.debug("received %d bytes", len(message))
             session.push(message)
 
 
 async def writer(ws: websockets.WebSocketServerProtocol, session: EchoSession) -> None:
     """Run session processing loop and stream synthesized speech."""
+    log.debug("writer start")
     await session.tick(ws)
+    log.debug("writer end")
+
+
+async def health(_request: web.Request) -> web.Response:
+    """Simple healthcheck endpoint."""
+    return web.Response(text="OK")
 
 
 async def start_server() -> None:
-    """Load configuration, initialise engines and start websocket server."""
+    """Load configuration, initialise engines and start servers."""
     cfg = load_config()
+    log.info(
+        "starting servers ws_port=%d http_port=%d", cfg.ws_port, cfg.http_port
+    )
     asr = AsrEngine(cfg)
 
     if cfg.tts_engine.lower() == "piper":
@@ -41,14 +55,26 @@ async def start_server() -> None:
         raise ValueError(f"Unknown TTS engine: {cfg.tts_engine}")
 
     async def handler(ws: websockets.WebSocketServerProtocol) -> None:
+        log.info("websocket connected")
         session = EchoSession(cfg, asr, tts)
         r_task = asyncio.create_task(reader(ws, session))
         w_task = asyncio.create_task(writer(ws, session))
         done, pending = await asyncio.wait({r_task, w_task}, return_when=asyncio.FIRST_COMPLETED)
         for task in pending:
             task.cancel()
+        log.info("websocket disconnected")
 
-    async with websockets.serve(handler, "0.0.0.0", cfg.ws_port):
+    ws_server = websockets.serve(handler, "0.0.0.0", cfg.ws_port)
+
+    app = web.Application()
+    app.router.add_get("/health", health)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", cfg.http_port)
+    await site.start()
+    log.info("health endpoint started")
+
+    async with ws_server:
         await asyncio.Future()
 
 

--- a/server/session.py
+++ b/server/session.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
@@ -42,9 +44,11 @@ class EchoSession:
         self.stabilizer = Stabilizer()
         self.window_samples = max_samples
         self.step_samples = int(config.asr_sr * STEP_SEC)
+        self.log = logging.getLogger(__name__)
 
     def push(self, data: bytes) -> None:
         """Append raw PCM16 bytes to the internal ring buffer."""
+        self.log.debug("push %d bytes", len(data))
         self.ring.push_pcm16(data)
 
     async def tick(self, ws) -> None:
@@ -58,16 +62,36 @@ class EchoSession:
         try:
             while True:
                 await asyncio.sleep(STEP_SEC)
+                self.log.debug("tick start")
 
                 window = self.ring.window(self.window_samples)
                 audio = window.astype(np.float32) / 32768.0
+
+                start_asr = time.perf_counter()
                 hyp = self.asr.transcribe_window(audio)
+                mic_to_asr = time.perf_counter() - start_asr
+                self.log.debug("ASR hypothesis: %s", hyp.strip())
                 delta = self.stabilizer.get_delta(hyp)
 
                 if delta:
+                    start_tts = time.perf_counter()
                     pcm = self.tts.synthesize(delta)
+                    asr_to_tts = time.perf_counter() - start_tts
+
+                    start_play = time.perf_counter()
                     await ws.send(pcm)
+                    tts_to_play = time.perf_counter() - start_play
+
+                    self.log.info(
+                        "metrics mic→asr=%.3f asr→tts=%.3f tts→play=%.3f",
+                        mic_to_asr,
+                        asr_to_tts,
+                        tts_to_play,
+                    )
+                else:
+                    self.log.info("metrics mic→asr=%.3f", mic_to_asr)
 
                 self.ring.step(self.step_samples)
+                self.log.debug("tick end")
         except asyncio.CancelledError:  # pragma: no cover - cancellation flow
             pass

--- a/server/tts_silero.py
+++ b/server/tts_silero.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 """Minimal Silero TTS placeholder used for tests and local development."""
 
+import logging
 import numpy as np
 
 from common.audio import float32_to_pcm16
+
+
+log = logging.getLogger(__name__)
 
 
 class SileroTTS:
@@ -23,6 +27,7 @@ class SileroTTS:
     def __init__(self, speaker: str = "ru_v3", device: str = "cpu") -> None:
         self.speaker = speaker
         self.device = device
+        log.info("SileroTTS initialized speaker=%s", speaker)
 
     def synthesize(self, text: str) -> bytes:
         """Return a short silence placeholder for the given text."""
@@ -30,4 +35,6 @@ class SileroTTS:
         duration = max(len(text) * 0.05, 0.2)  # seconds of audio
         samples = int(self.sample_rate * duration)
         silence = np.zeros(samples, dtype=np.float32)
-        return float32_to_pcm16(silence)
+        pcm = float32_to_pcm16(silence)
+        log.debug("synthesize produced %d bytes", len(pcm))
+        return pcm


### PR DESCRIPTION
## Summary
- instrument echo session with detailed logging and latency metrics between mic, ASR, TTS and playback
- expose simple aiohttp `/health` endpoint and start dedicated HTTP server
- extend configuration with `HTTP_PORT`

## Testing
- `pip install numpy aiohttp pytest-aiohttp -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b373cc5364832284290e65388943ee