### PR TITLE
Add Docker and compose setup with GPU profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE=python:3.10-slim
+FROM ${BASE_IMAGE}
+
+# Install Python (if missing) and build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        python3 \
+        python3-pip \
+        python3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python3", "-m", "server.server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# To start GPU service use:
+#   docker compose --profile gpu up --gpus all
+version: "3.8"
+
+services:
+  app:
+    build: .
+    environment:
+      ASR_MODEL: ${ASR_MODEL:-small}
+      ASR_DEVICE: ${ASR_DEVICE:-cpu}
+      ASR_COMPUTE_TYPE: ${ASR_COMPUTE_TYPE:-int8}
+      ASR_SR: ${ASR_SR:-16000}
+      WS_PORT: ${WS_PORT:-8000}
+      HTTP_PORT: ${HTTP_PORT:-8080}
+      TTS_ENGINE: ${TTS_ENGINE:-piper}
+      RU_SPEAKER: ${RU_SPEAKER:-kseniya_16khz}
+    ports:
+      - "${HTTP_PORT:-8080}:${HTTP_PORT:-8080}"
+      - "${WS_PORT:-8000}:${WS_PORT:-8000}"
+
+  gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      args:
+        BASE_IMAGE: nvidia/cuda:12.1-runtime
+    environment:
+      ASR_MODEL: ${ASR_MODEL:-small}
+      ASR_DEVICE: ${ASR_DEVICE:-cpu}
+      ASR_COMPUTE_TYPE: ${ASR_COMPUTE_TYPE:-int8}
+      ASR_SR: ${ASR_SR:-16000}
+      WS_PORT: ${WS_PORT:-8000}
+      HTTP_PORT: ${HTTP_PORT:-8080}
+      TTS_ENGINE: ${TTS_ENGINE:-piper}
+      RU_SPEAKER: ${RU_SPEAKER:-kseniya_16khz}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+    ports:
+      - "${HTTP_PORT:-8080}:${HTTP_PORT:-8080}"
+      - "${WS_PORT:-8000}:${WS_PORT:-8000}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+aiohttp
+websockets
+faster-whisper
+numpy
+webrtcvad
+onnxruntime
+piper-phonemize
+sounddevice
+resampy
+scipy
+pytest


### PR DESCRIPTION
## Summary
- add Dockerfile and requirements for Python 3.10 environment
- provide docker-compose with env vars and optional GPU profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b374d8f53c8322a79a3ebba5c507b4