### PR TITLE
Add Makefile targets and quickstart docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: run-server run-client lint typecheck test
+
+run-server:
+	python -m server.server
+
+run-client:
+	python - <<'PY'
+import asyncio
+from rt_echo.client import MicStreamer, PcmPlayer
+from rt_echo.client.ws_client import run
+asyncio.run(run("ws://localhost:8000", MicStreamer(), PcmPlayer()))
+PY
+
+lint:
+	ruff check .
+
+typecheck:
+	mypy server tests --ignore-missing-imports
+
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
-# Interview Assistant MVP (skeleton)
+# Interview Assistant MVP
 
-Этот репозиторий очищен. Содержит только README.  
-Исходный код сервисов ASR/TTS/LLM/IE/Scoring удалён.  
-Используй как заготовку для новой разработки.
+## Quickstart
+
+### CPU
+
+```bash
+pip install -r requirements.txt
+make run-server
+make run-client
+```
+
+### GPU
+
+```bash
+docker compose --profile gpu up --build --gpus all
+```
+
+## Supported Russian voices for Piper
+
+- denis
+- dmitri
+- irina
+- ruslan
+
+## Latency reduction tips
+
+- Use smaller ASR models (`ASR_MODEL=small`).
+- Run ASR and TTS on GPU when available (`ASR_DEVICE=gpu`).
+- Stream shorter audio chunks (20 ms) to the server.
+- Preload models to avoid cold starts.

--- a/server/asr.py
+++ b/server/asr.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Automatic speech recognition utilities using faster-whisper."""
+
+from __future__ import annotations
 
 import logging
 import numpy as np

--- a/server/stabilizer.py
+++ b/server/stabilizer.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Hypothesis stabilization utilities."""
+
+from __future__ import annotations
 
 from collections import deque
 from typing import Deque, List

--- a/server/tts_piper.py
+++ b/server/tts_piper.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Text-to-speech utilities using Piper models."""
+
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/server/tts_silero.py
+++ b/server/tts_silero.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Minimal Silero TTS placeholder used for tests and local development."""
+
+from __future__ import annotations
 
 import logging
 import numpy as np

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -73,7 +73,7 @@ async def run_test():
     asr = DummyAsr()
     tts = DummyTTS()
 
-    async def handler(ws: websockets.WebSocketServerProtocol) -> None:
+    async def handler(ws) -> None:
         session = EchoSession(cfg, asr, tts)
         r_task = asyncio.create_task(reader(ws, session))
         w_task = asyncio.create_task(writer(ws, session))

--- a/tests/test_stabilizer.py
+++ b/tests/test_stabilizer.py
@@ -1,7 +1,5 @@
 import os
 import sys
-import pytest
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from server.stabilizer import Stabilizer
 


### PR DESCRIPTION
## Summary
- Add Makefile with run-server, run-client, lint, typecheck, and test targets
- Document CPU/GPU quickstart, available Russian Piper voices, and latency tips
- Improve imports and typing for cleaner lint/typecheck runs

## Testing
- `ruff check .`
- `mypy server tests --ignore-missing-imports`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3772c8cd08322a8b86bc2a399a554