### PR TITLE
Add configuration presets and profile selector

### DIFF
--- a/rt_echo/common/config.py
+++ b/rt_echo/common/config.py
@@ -16,18 +16,44 @@ class AppConfig:
     http_port: int = 8080
     tts_engine: str = "piper"
     ru_speaker: str = "kseniya_16khz"
+    window_sec: float = 2.0
+    step_sec: float = 0.5
 
 
 def load_config() -> AppConfig:
     """Load :class:`AppConfig` from environment variables."""
+    profile = os.getenv("APP_PROFILE", "balanced")
+    presets = {
+        "fast": {
+            "asr_model": "small",
+            "asr_compute_type": "int8",
+            "window_sec": 0.8,
+            "step_sec": 0.25,
+        },
+        "balanced": {
+            "asr_model": "medium",
+            "asr_compute_type": "int8",
+            "window_sec": 2.0,
+            "step_sec": 0.5,
+        },
+        "quality": {
+            "asr_model": "large-v3",
+            "asr_compute_type": "fp16",
+            "window_sec": 2.0,
+            "step_sec": 0.5,
+        },
+    }
+    preset = presets.get(profile, presets["balanced"])
 
     return AppConfig(
-        asr_model=os.getenv("ASR_MODEL", "small"),
+        asr_model=os.getenv("ASR_MODEL", preset["asr_model"]),
         asr_device=os.getenv("ASR_DEVICE", "cpu"),
-        asr_compute_type=os.getenv("ASR_COMPUTE_TYPE", "int8"),
+        asr_compute_type=os.getenv("ASR_COMPUTE_TYPE", preset["asr_compute_type"]),
         asr_sr=int(os.getenv("ASR_SR", 16000)),
         ws_port=int(os.getenv("WS_PORT", 8000)),
         http_port=int(os.getenv("HTTP_PORT", 8080)),
         tts_engine=os.getenv("TTS_ENGINE", "piper"),
         ru_speaker=os.getenv("RU_SPEAKER", "kseniya_16khz"),
+        window_sec=float(os.getenv("WINDOW_SEC", preset["window_sec"])),
+        step_sec=float(os.getenv("STEP_SEC", preset["step_sec"])),
     )

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from rt_echo.common.config import load_config
+
+
+def test_fast_profile(monkeypatch):
+    monkeypatch.setenv("APP_PROFILE", "fast")
+    cfg = load_config()
+    assert cfg.asr_model == "small"
+    assert cfg.asr_compute_type == "int8"
+    assert cfg.window_sec == 0.8
+    assert cfg.step_sec == 0.25
+
+
+def test_quality_profile(monkeypatch):
+    monkeypatch.setenv("APP_PROFILE", "quality")
+    cfg = load_config()
+    assert cfg.asr_model == "large-v3"
+    assert cfg.asr_compute_type == "fp16"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -69,7 +69,7 @@ async def run_client(uri: str, pcm_bytes: bytes):
 
 
 async def run_test():
-    cfg = SimpleNamespace(asr_sr=SAMPLE_RATE)
+    cfg = SimpleNamespace(asr_sr=SAMPLE_RATE, window_sec=2.0, step_sec=0.5)
     asr = DummyAsr()
     tts = DummyTTS()
 


### PR DESCRIPTION
## Summary
- support fast, balanced and quality presets in configuration
- make session and websocket server use configurable window and step sizes
- add tests for configuration profiles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37988aba08322a67e17d1934015e4