### PR TITLE
Ensure WebSocket audio is PCM16@16k

### DIFF
--- a/server/session.py
+++ b/server/session.py
@@ -9,13 +9,14 @@ import numpy as np
 
 from rt_echo.server.buffer import RingBuffer16k
 from .stabilizer import Stabilizer
+from .tts import ensure_pcm16_16k
 
 
 class TTS(Protocol):
     """Protocol describing minimal text-to-speech interface."""
 
-    def synthesize(self, text: str) -> bytes:
-        """Synthesize ``text`` into PCM16 bytes."""
+    def synthesize(self, text: str) -> tuple[np.ndarray, int]:
+        """Synthesize ``text`` into float32 audio and its sample rate."""
         ...
 
 
@@ -73,7 +74,8 @@ class EchoSession:
 
                 if delta:
                     start_tts = time.perf_counter()
-                    pcm = self.tts.synthesize(delta)
+                    audio, sr = self.tts.synthesize(delta)
+                    pcm = ensure_pcm16_16k(audio, sr)
                     asr_to_tts = time.perf_counter() - start_tts
 
                     start_play = time.perf_counter()

--- a/server/tts.py
+++ b/server/tts.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+
+from rt_echo.common.audio import resample
+
+
+TARGET_SR = 16_000
+
+
+def ensure_pcm16_16k(wav_f32: np.ndarray, sr: int) -> bytes:
+    """Convert ``wav_f32`` to PCM16 @ 16 kHz.
+
+    Any input floating point waveform with sample rate ``sr`` is first
+    resampled to 16 kHz if necessary, then clipped to ``[-1, 1]`` and
+    converted to 16-bit signed little-endian PCM bytes.
+    """
+
+    wav_f32 = np.asarray(wav_f32, dtype=np.float32)
+    if sr != TARGET_SR:
+        wav_f32 = resample(wav_f32, sr, TARGET_SR)
+    wav_f32 = np.clip(wav_f32, -1.0, 1.0)
+    return (wav_f32 * 32767).astype(np.int16).tobytes()

--- a/server/tts_silero.py
+++ b/server/tts_silero.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 import numpy as np
 
-from rt_echo.common.audio import float32_to_pcm16
-
 
 log = logging.getLogger(__name__)
 
@@ -29,12 +27,11 @@ class SileroTTS:
         self.device = device
         log.info("SileroTTS initialized speaker=%s", speaker)
 
-    def synthesize(self, text: str) -> bytes:
+    def synthesize(self, text: str) -> tuple[np.ndarray, int]:
         """Return a short silence placeholder for the given text."""
 
         duration = max(len(text) * 0.05, 0.2)  # seconds of audio
         samples = int(self.sample_rate * duration)
         silence = np.zeros(samples, dtype=np.float32)
-        pcm = float32_to_pcm16(silence)
-        log.debug("synthesize produced %d bytes", len(pcm))
-        return pcm
+        log.debug("synthesize produced %d samples", len(silence))
+        return silence, self.sample_rate

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -25,10 +25,10 @@ class DummyAsr:
 
 
 class DummyTTS:
-    """Stub TTS that returns non-empty PCM16 bytes."""
+    """Stub TTS that returns non-empty float audio."""
 
-    def synthesize(self, _text: str) -> bytes:
-        return b"\x00\x01" * 100
+    def synthesize(self, _text: str) -> tuple[np.ndarray, int]:
+        return np.zeros(200, dtype=np.float32), SAMPLE_RATE
 
 
 async def reader(ws, session) -> None:

--- a/tests/test_tts_piper.py
+++ b/tests/test_tts_piper.py
@@ -7,6 +7,7 @@ import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from rt_echo.common.audio import float32_to_pcm16, resample
+from server.tts import ensure_pcm16_16k
 from server.tts_piper import PiperTTS
 
 
@@ -38,7 +39,8 @@ def test_synthesize(monkeypatch, tmp_path):
     )
 
     tts = PiperTTS(str(model_path), str(speaker_json))
-    pcm_bytes = tts.synthesize("hello")
+    out_audio, sr = tts.synthesize("hello")
+    pcm_bytes = ensure_pcm16_16k(out_audio, sr)
 
     expected = float32_to_pcm16(audio)
     assert pcm_bytes == expected
@@ -71,7 +73,8 @@ def test_resample(monkeypatch, tmp_path):
     )
 
     tts = PiperTTS(str(model_path), str(speaker_json), model_sample_rate=8_000)
-    pcm_bytes = tts.synthesize("hello")
+    out_audio, sr = tts.synthesize("hello")
+    pcm_bytes = ensure_pcm16_16k(out_audio, sr)
 
     expected_audio = resample(audio, 8_000, tts.sample_rate)
     expected = float32_to_pcm16(expected_audio)


### PR DESCRIPTION
## Summary
- add ensure_pcm16_16k utility to resample and pack float audio into PCM16
- stream TTS output via ensure_pcm16_16k and adjust TTS classes to return float audio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42e7959508322992a290b5831ed5f