### PR TITLE
docs: add cpu/gpu quickstart and presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,80 @@
 
 ### CPU
 
-```bash
-pip install -r requirements.txt
-make run-server
-make run-client
-```
+1. Install Docker:
+
+   ```bash
+   curl -fsSL https://get.docker.com | sh
+   sudo apt-get install -y docker-compose-plugin
+   ```
+
+2. Start the service:
+
+   ```bash
+   make run-server
+   ```
+
+3. Run an offline test and convert the output to WAV:
+
+   ```bash
+   make test-offline
+   ffmpeg -f s16le -ar 16000 -ac 1 -i tts_out.pcm out.wav -y
+   ```
+
+4. Measure latency:
+
+   ```bash
+   python measure_latency.py --ws ws://localhost:8000 --wav ru_test.wav
+   ```
+
+5. Stop the containers:
+
+   ```bash
+   docker compose down
+   ```
 
 ### GPU
 
-```bash
-docker compose --profile gpu up --build --gpus all
-```
+1. Install Docker and NVIDIA Container Toolkit:
+
+   ```bash
+   curl -fsSL https://get.docker.com | sh
+   sudo apt-get install -y docker-compose-plugin nvidia-container-toolkit
+   sudo nvidia-ctk runtime configure --runtime=docker
+   sudo systemctl restart docker
+   ```
+
+2. Start the GPU service:
+
+   ```bash
+   make run-gpu
+   ```
+
+3. Run an offline test and convert the output to WAV:
+
+   ```bash
+   make test-offline
+   ffmpeg -f s16le -ar 16000 -ac 1 -i tts_out.pcm out.wav -y
+   ```
+
+4. Measure latency:
+
+   ```bash
+   python measure_latency.py --ws ws://localhost:8000 --wav ru_test.wav
+   ```
+
+5. Stop the containers:
+
+   ```bash
+   docker compose down
+   ```
+
+## Presets
+
+| Environment | `ASR_MODEL` | `ASR_COMPUTE_TYPE` |
+|-------------|-------------|--------------------|
+| CPU         | small       | int8               |
+| GPU         | large-v3    | float16            |
 
 ## Supported Russian voices for Piper
 


### PR DESCRIPTION
## Summary
- add CPU quickstart with Docker install, offline test and latency script
- add GPU quickstart with NVIDIA toolkit steps
- document preset table for ASR model sizes and compute types

## Testing
- `make lint`
- `make types` *(fails: mypy errors in audio module and websocket types)*
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_68b430478b708322a89c0e96f74b46d7