### PR TITLE
Add simple health check endpoint to server

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp>=3.12
 faster-whisper>=1.0.0
 websockets>=12.0
 numpy>=1.24


### PR DESCRIPTION
## Summary
- serve WebSocket echo server and `/healthz` via aiohttp
- log startup messages for WebSocket port and health endpoint
- include `aiohttp` in server requirements

## Testing
- `make lint`
- `make types` *(fails: Returning Any from function declared to return ndarray, WebSocketClientProtocol not defined)*
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_68b430adade48322b7d6b42ec8265ec4