### PR TITLE
Add server entry with health endpoint and typing cleanup

### DIFF
--- a/rt_echo/client/player.py
+++ b/rt_echo/client/player.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-import asyncio
 from typing import Optional
 
 import numpy as np
@@ -8,76 +5,26 @@ import sounddevice as sd
 
 
 class PcmPlayer:
-    """Play PCM16 audio blocks using ``sounddevice``."""
-
-    def __init__(self, queue_size: int = 5) -> None:
-        self._queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=queue_size)
+    def __init__(self, samplerate: int = 16000) -> None:
+        self._sr = samplerate
         self._stream: Optional[sd.OutputStream] = None
-        self._buffer = b""
-        self._stopping = False
-        self._drained = asyncio.Event()
 
-    def _callback(
-        self,
-        outdata: np.ndarray,
-        frames: int,
-        time: sd.CallbackTime,
-        status: sd.CallbackFlags,
-    ) -> None:
-        """Callback for ``sounddevice`` that feeds audio from the queue."""
-        if status:
-            # For simplicity, ignore status but could log/handle it.
-            pass
+    def start(self) -> None:
+        if self._stream is None:
+            self._stream = sd.OutputStream(samplerate=self._sr, channels=1, dtype="int16")
+            self._stream.start()
 
-        bytes_needed = frames * 2  # int16 -> 2 bytes per frame
-        out = memoryview(outdata).cast("b")
-        idx = 0
-        while bytes_needed > 0:
-            if self._buffer:
-                take = min(len(self._buffer), bytes_needed)
-                out[idx : idx + take] = self._buffer[:take]
-                self._buffer = self._buffer[take:]
-                idx += take
-                bytes_needed -= take
-            else:
-                try:
-                    chunk = self._queue.get_nowait()
-                    self._queue.task_done()
-                except asyncio.QueueEmpty:
-                    # Underrun: fill remaining buffer with silence
-                    out[idx : idx + bytes_needed] = b"\x00" * bytes_needed
-                    bytes_needed = 0
-                else:
-                    self._buffer = chunk
+    def play(self, pcm: bytes) -> None:
+        assert self._stream is not None
+        arr = np.frombuffer(pcm, dtype=np.int16)
+        self._stream.write(arr)
 
-        if self._stopping and not self._buffer and self._queue.empty():
-            self._drained.set()
-
-    async def __aenter__(self) -> "PcmPlayer":
-        self._stopping = False
-        self._drained.clear()
-        self._stream = sd.OutputStream(
-            samplerate=16000,
-            channels=1,
-            dtype="int16",
-            blocksize=320,
-            callback=self._callback,
-        )
-        self._stream.start()
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb) -> None:
-        await self.stop()
-
-    async def play(self, bytes_pcm16: bytes) -> None:
-        """Queue a PCM16 audio block for playback."""
-        await self._queue.put(bytes_pcm16)
-
-    async def stop(self) -> None:
-        """Stop playback after draining the queue."""
-        self._stopping = True
-        await self._drained.wait()
+    def stop(self) -> None:
         if self._stream is not None:
             self._stream.stop()
             self._stream.close()
             self._stream = None
+
+
+__all__ = ["PcmPlayer"]
+

--- a/rt_echo/server/asr.py
+++ b/rt_echo/server/asr.py
@@ -1,0 +1,29 @@
+"""Compatibility wrapper adapting :class:`AsrEngine` from ``server.asr``."""
+
+from types import SimpleNamespace
+
+from server.asr import AsrEngine as _AsrEngine
+
+
+class AsrEngine(_AsrEngine):
+    """Adapter that mirrors new constructor signature.
+
+    Parameters
+    ----------
+    model: str
+        Whisper model identifier.
+    device: str
+        Device to run the model on.
+    compute_type: str
+        Computation type passed to Faster-Whisper.
+    """
+
+    def __init__(self, model: str, device: str, compute_type: str):
+        cfg = SimpleNamespace(
+            asr_model=model, asr_device=device, asr_compute_type=compute_type
+        )
+        super().__init__(cfg)
+
+
+__all__ = ["AsrEngine"]
+

--- a/rt_echo/server/session.py
+++ b/rt_echo/server/session.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for :class:`EchoSession` from ``server.session``."""
+
+from server.session import EchoSession
+
+__all__ = ["EchoSession"]
+

--- a/rt_echo/server/tts_piper.py
+++ b/rt_echo/server/tts_piper.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper exposing :class:`PiperTTS` from ``server.tts_piper``."""
+
+from server.tts_piper import PiperTTS
+
+__all__ = ["PiperTTS"]
+

--- a/rt_echo/server/tts_silero.py
+++ b/rt_echo/server/tts_silero.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper exposing :class:`SileroTTS` from ``server.tts_silero``."""
+
+from server.tts_silero import SileroTTS
+
+__all__ = ["SileroTTS"]
+


### PR DESCRIPTION
## Summary
- Replace server entrypoint with config-driven ASR→TTS websocket bridge and /healthz probe
- Add audio helpers and simple PCM player with type hints
- Provide websocket client and script annotations; expose server modules under `rt_echo.server`

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
- `docker compose up -d --build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b4349c82208322a07a30bab8a9eb6d